### PR TITLE
CVE-2016-4433

### DIFF
--- a/cves/CVE-2016-4433.yml
+++ b/cves/CVE-2016-4433.yml
@@ -96,7 +96,7 @@ upvotes_instructions: |
   upvotes to each vulnerability you see. Your peers will tell you how
   interesting they think this vulnerability is, and you'll add that to the
   upvotes score on your branch.
-upvotes:
+upvotes: 3
 
 unit_tested:
   question: |
@@ -234,3 +234,7 @@ mistakes:
     source it seems like the use of it is a design flaw, as Apache will be
     forever plugging holes in this system. Instead the app should be required to
     define its input paths, instead of letting the client do whatever it wants.
+
+    The only real way I can think of to avoid this in the future is to not have
+    a feature like OGNL, instead just require the app to define its endpoints
+    like in a Spring app.

--- a/cves/CVE-2016-4433.yml
+++ b/cves/CVE-2016-4433.yml
@@ -12,7 +12,7 @@ CWE_instructions: |
   Please go to cwe.mitre.org and find the most specific, appropriate CWE entry
   that describes your vulnerability. (Tip: this may not be a good one to start
   with - spend time understanding this vulnerability before making your choice!)
-CWE:
+CWE: CWE-20
 
 curated_instructions: |
   If you are manually editing this file, then you are "curating" it. Set the
@@ -20,19 +20,19 @@ curated_instructions: |
   integrity checks on this file to make sure you fill everything out properly.
   If you are a student, we cannot accept your work as finished unless curated is
   set to true.
-curated: false
+curated: true
 
 reported_instructions: |
   Was there a date that this vulnerability was reported to the team? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE data.
   Please enter your date in YYYY-MM-DD format.
-reported:
+reported: 2016-06-20
 
 announced_instructions: |
   Was there a date that this vulnerability was announced to the world? You can
   find this in changelogs, blogs, bug reports, or perhaps the CVE data.
   Please enter your date in YYYY-MM-DD format.
-announced:
+announced: 2016-06-20
 
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
@@ -45,7 +45,14 @@ description_instructions: |
   that outsiders to Struts would not understand. Technology like "regular
   expressions" is fine, and security phrases like "invalid write" are fine to
   keep too.
-description:
+description: |
+  A properly made request to Struts will allow an attacker to bypass permissions
+  and conduct a redirection attack.
+
+  A redirection attack is where the attacker can control where a page will
+  redirect the user to. It may for example redirect them to a fake login page
+  intended to harvest their username/password. The user is likely to trust this
+  fake page, given they just came from a trusted page.
 
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
@@ -103,9 +110,11 @@ unit_tested:
     For the "fix" answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
     Must be just "true" or "false".
-  answer:
-  code:
-  fix:
+  answer: |
+    There are unit tests for the OGNL module, and the fix included additioanl
+    unit tests to check that invalid/insecure OGNL specifications were rejected.
+  code: true
+  fix: true
 
 discovered:
   question: |
@@ -119,7 +128,7 @@ discovered:
     The "apache" flag can be true, false, or nil.
     If there is no evidence as to how this vulnerability was found, then you may
     leave the entries blank except for "answer". Write down where you looked in "answer".
-  answer:
+  answer: No discovery method given
   date:
   automated:
   apache:
@@ -131,8 +140,8 @@ subsystem:
     Look at the path of the source code files code that were fixed to get
     directory names. Look at comments in the code. Look at the bug reports how
     the bug report was tagged. Examples: "clipboard", "gpu", "ssl", "speech", "renderer"
-  answer:
-  name:
+  answer: Based on filenames.
+  name: OGNL
 
 interesting_commits:
   question: |
@@ -174,8 +183,10 @@ lessons:
     applies:
     note:
   distrust_input:
-    applies:
-    note:
+    applies: true
+    note: |
+      Struts initially placed a fair amount of trust in the input it was given,
+      the fix limits what can be specified in the input to OGNL.
   security_by_obscurity:
     applies:
     note:
@@ -192,8 +203,13 @@ lessons:
     applies:
     note:
   complex_inputs:
-    applies:
-    note:
+    applies: true
+    note: |
+      The CVE description says exploitation requires a "crafted request", which
+      does not sound trivial to me. I found an example of one such request in a
+      test "#booScope=@myclass@DEFAULT_SCOPE,#bootScope.init()". This is OGNL,
+      and per what I found on Wikipedia, it allows the execution of methods
+      with arbitrary parameters.
 
 mistakes:
   question: |
@@ -205,4 +221,13 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those in the software
     engineering industry would find interesting.
-  answer:
+  answer: |
+    Looking at the fix I notice they're disallowing arithmetic expressions, so
+    perhaps plus symbols were being expanded to spaces later for example,
+    causing issues. Looking into the test added at the fix commit it expects a
+    method call of "#booScope=@myclass@DEFAULT_SCOPE,#bootScope.init()" to fail.
+
+    Given that this syntax appears to allow arbitrary method calls from a remote
+    source it seems like the use of it is a design flaw, as Apache will be
+    forever plugging holes in this system. Instead the app should be required to
+    define its input paths, instead of letting the client do whatever it wants.

--- a/cves/CVE-2016-4433.yml
+++ b/cves/CVE-2016-4433.yml
@@ -72,8 +72,8 @@ fixes:
   - commit:
     note:
 vccs:
-  - commit:
-    note:
+  - commit: 0c543aef318341ca9bd482e15f1637497b8a4dfd
+    note: OgnlUtil from XWork core was moved into Struts at this commit
   - commit:
     note:
 
@@ -151,12 +151,15 @@ interesting_commits:
     emerging themes?
     If there are no interesting commits, demonstrate that you completed this section
     by explaining what happened between the VCCs and the fix.
-  answer:
+  answer: |
+    The first commit listed disables eval expressions in OGNL, which allowed
+    arbitary code execution. The second one blocks chained expressions,
+    presumably due to another security issue (the commit doesn't link anything)
   commits:
-    - commit:
-      note:
-    - commit:
-      note:
+    - commit: 7e6f641ebb142663cbd1653dc49bed725edf7f56
+      note: https://cwiki.apache.org/confluence/display/WW/S2-013 (linked in commit)
+    - commit: 5190b53673a710ead31bbb5f82cf4ca171994629
+      note: None
 
 lessons:
   question: |


### PR DESCRIPTION
Filling in YML for CVE-2016-4433 "Apache Struts 2 2.3.20 through 2.3.28.1 allows remote attackers to bypass intended access restrictions and conduct redirection attacks via a crafted request."